### PR TITLE
Add WriteAndClear to Metric interface as design PoC

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -108,7 +108,12 @@ func (c *counter) Inc() {
 }
 
 func (c *counter) WriteAndClear(out *dto.Metric) error {
-	return nil
+	fval := math.Float64frombits(atomic.LoadUint64(&c.valBits))
+	ival := atomic.LoadUint64(&c.valInt)
+	val := fval + float64(ival)
+	atomic.StoreUint64(&c.valInt, 0)
+
+	return populateMetric(CounterValue, val, c.labelPairs, out)
 }
 
 func (c *counter) Write(out *dto.Metric) error {

--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -107,6 +107,10 @@ func (c *counter) Inc() {
 	atomic.AddUint64(&c.valInt, 1)
 }
 
+func (c *counter) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
+
 func (c *counter) Write(out *dto.Metric) error {
 	fval := math.Float64frombits(atomic.LoadUint64(&c.valBits))
 	ival := atomic.LoadUint64(&c.valInt)

--- a/prometheus/gauge.go
+++ b/prometheus/gauge.go
@@ -120,6 +120,9 @@ func (g *gauge) Add(val float64) {
 func (g *gauge) Sub(val float64) {
 	g.Add(val * -1)
 }
+func (g *gauge) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
 
 func (g *gauge) Write(out *dto.Metric) error {
 	val := math.Float64frombits(atomic.LoadUint64(&g.valBits))

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -293,6 +293,9 @@ func (h *histogram) Observe(v float64) {
 	atomic.AddUint64(&hotCounts.count, 1)
 }
 
+func (h *histogram) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
 func (h *histogram) Write(out *dto.Metric) error {
 	// For simplicity, we protect this whole method by a mutex. It is not in
 	// the hot path, i.e. Observe is called much more often than Write. The
@@ -493,6 +496,10 @@ type constHistogram struct {
 
 func (h *constHistogram) Desc() *Desc {
 	return h.desc
+}
+
+func (h *constHistogram) WriteAndClear(out *dto.Metric) error {
+	return nil
 }
 
 func (h *constHistogram) Write(out *dto.Metric) error {

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -294,8 +294,19 @@ func (h *histogram) Observe(v float64) {
 }
 
 func (h *histogram) WriteAndClear(out *dto.Metric) error {
+	err := h.Write(out)
+	if err != nil {
+		return err
+	}
+
+	h.writeMtx.Lock()
+	defer h.writeMtx.Unlock()
+
+	h.counts[0].buckets = make([]uint64, len(h.upperBounds))
+	h.counts[1].buckets = make([]uint64, len(h.upperBounds))
 	return nil
 }
+
 func (h *histogram) Write(out *dto.Metric) error {
 	// For simplicity, we protect this whole method by a mutex. It is not in
 	// the hot path, i.e. Observe is called much more often than Write. The

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -53,6 +53,8 @@ type Metric interface {
 	// dto.Metric protobuf to save allocations has disappeared. The
 	// signature of this method should be changed to "Write() (*dto.Metric,
 	// error)".
+
+	WriteAndClear(*dto.Metric) error
 }
 
 // Opts bundles the options for creating most Metric types. Each metric
@@ -143,7 +145,8 @@ func NewInvalidMetric(desc *Desc, err error) Metric {
 
 func (m *invalidMetric) Desc() *Desc { return m.desc }
 
-func (m *invalidMetric) Write(*dto.Metric) error { return m.err }
+func (m *invalidMetric) WriteAndClear(*dto.Metric) error { return m.err }
+func (m *invalidMetric) Write(*dto.Metric) error         { return m.err }
 
 type timestampedMetric struct {
 	Metric

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -287,6 +287,9 @@ func (s *summary) Observe(v float64) {
 	}
 }
 
+func (s *summary) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
 func (s *summary) Write(out *dto.Metric) error {
 	sum := &dto.Summary{}
 	qs := make([]*dto.Quantile, 0, len(s.objectives))
@@ -445,7 +448,9 @@ func (s *noObjectivesSummary) Observe(v float64) {
 	// is complete.
 	atomic.AddUint64(&hotCounts.count, 1)
 }
-
+func (s *noObjectivesSummary) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
 func (s *noObjectivesSummary) Write(out *dto.Metric) error {
 	// For simplicity, we protect this whole method by a mutex. It is not in
 	// the hot path, i.e. Observe is called much more often than Write. The
@@ -656,6 +661,10 @@ type constSummary struct {
 
 func (s *constSummary) Desc() *Desc {
 	return s.desc
+}
+
+func (s *constSummary) WriteAndClear(out *dto.Metric) error {
+	return nil
 }
 
 func (s *constSummary) Write(out *dto.Metric) error {

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -68,6 +68,10 @@ func (v *valueFunc) Desc() *Desc {
 	return v.desc
 }
 
+func (v *valueFunc) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
+
 func (v *valueFunc) Write(out *dto.Metric) error {
 	return populateMetric(v.valType, v.function(), v.labelPairs, out)
 }
@@ -115,6 +119,9 @@ func (m *constMetric) Desc() *Desc {
 	return m.desc
 }
 
+func (m *constMetric) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
 func (m *constMetric) Write(out *dto.Metric) error {
 	return populateMetric(m.valType, m.val, m.labelPairs, out)
 }

--- a/prometheus/wrap.go
+++ b/prometheus/wrap.go
@@ -154,6 +154,10 @@ func (m *wrappingMetric) Desc() *Desc {
 	return wrapDesc(m.wrappedMetric.Desc(), m.prefix, m.labels)
 }
 
+func (m *wrappingMetric) WriteAndClear(out *dto.Metric) error {
+	return nil
+}
+
 func (m *wrappingMetric) Write(out *dto.Metric) error {
 	if err := m.wrappedMetric.Write(out); err != nil {
 		return err


### PR DESCRIPTION
This looks to be the most straight forward way to clear metrics with the go library and be goroutine safe.
Note: WriteAndClear() is not implemented. Getting a feel for what the API would look like.

With this change we'd add something like this in lambda main:

```
// True here causes the metrics to be cleared out after gathering.
reg := prometheus.NewRegistryOpts(true)
	prometheus.DefaultRegisterer = reg
	prometheus.DefaultGatherer = reg
```

